### PR TITLE
fix: improve context search input focus contrast

### DIFF
--- a/assets/sass/bulma/components/context-menu.sass
+++ b/assets/sass/bulma/components/context-menu.sass
@@ -33,4 +33,7 @@
 
     &:focus 
       background: $white
-
+      color: $black
+      &::placeholder
+        color: $dark1
+        opacity: 0.7


### PR DESCRIPTION
## Summary
- set explicit text color for focused search input in context menu
- improve focused placeholder contrast for readability

## Why
Typing in the search box could appear low-contrast against the white focus background.
This makes focused input text consistently readable across sites using this theme.