### PR TITLE
fix: enhance language preference handling with expiry and validation checks

### DIFF
--- a/assets/js/lang-redirect.js
+++ b/assets/js/lang-redirect.js
@@ -23,15 +23,39 @@
         var REDIRECT_ENABLED = {{ with .Site.Params.langRedirectEnabled }}{{ . }}{{ else }}true{{ end }};
         if (!REDIRECT_ENABLED) { log('skip: disabled by config'); return; }
 
+        // If the user has an explicit saved language preference (including English),
+        // respect it and skip auto-detection entirely.
+        try {
+            var _stored = localStorage.getItem('qgis-preferred-language');
+            if (_stored) {
+                var _pref;
+                try { _pref = JSON.parse(_stored); } catch (e) { _pref = { lang: _stored, ts: Date.now() }; }
+                var _expDays = 365;
+                if (_pref && _pref.lang && (Date.now() - (_pref.ts || 0)) / 86400000 <= _expDays) {
+                    log('skip: explicit user preference', _pref.lang); return;
+                }
+            }
+        } catch (e) { /* storage unavailable, continue with detection */ }
+
         // Coverage data and threshold from Hugo data/params
         var COVERAGE = {{- with .Site.Data.tx_coverage -}}{{- . | jsonify -}}{{- else -}}{}{{- end -}};
-        var THRESHOLD = {{ with .Site.Params.langRedirectThreshold }}{{ . }}{{ else }}80{{ end }};
+        var THRESHOLD = {{ with .Site.Params.langRedirectThreshold }}{{ . }}{{ else }}35{{ end }};
         log('threshold', THRESHOLD);
 
         // Redirect from any non-prefixed path (not only root)
 
-        // Supported language slugs from site languages (reflect URL prefixes)
-        var LANG_SLUGS = {{- $slugs := slice -}}{{- range .Site.Languages -}}{{- $slugs = $slugs | append .Lang -}}{{- end -}}{{- $slugs | jsonify -}};
+        // Supported language slugs: languages from data/languages.json meeting the coverage threshold.
+        // Uses the same source of truth as the language switcher dropdown.
+        {{- $lrThreshold := .Site.Params.langRedirectThreshold | default 35 | float -}}
+        {{- $lrCoverage := .Site.Data.tx_coverage -}}
+        {{- $lrSlugs := slice -}}
+        {{- range .Site.Data.languages -}}
+            {{- $cov := index $lrCoverage .code | default 0.0 | float -}}
+            {{- if ge $cov $lrThreshold -}}
+                {{- $lrSlugs = $lrSlugs | append .code -}}
+            {{- end -}}
+        {{- end -}}
+        var LANG_SLUGS = {{ $lrSlugs | jsonify }};
         log('LANG_SLUGS', LANG_SLUGS);
         if (!Array.isArray(LANG_SLUGS) || LANG_SLUGS.length === 0) { return; }
 

--- a/assets/js/lang-redirect.js
+++ b/assets/js/lang-redirect.js
@@ -54,7 +54,7 @@
             {{- if ge $cov $lrThreshold -}}
                 {{- $lrSlugs = $lrSlugs | append .code -}}
             {{- end -}}
-        {{- end -}}
+        {{- end }}
         var LANG_SLUGS = {{ $lrSlugs | jsonify }};
         log('LANG_SLUGS', LANG_SLUGS);
         if (!Array.isArray(LANG_SLUGS) || LANG_SLUGS.length === 0) { return; }

--- a/assets/js/language-switcher.js
+++ b/assets/js/language-switcher.js
@@ -11,6 +11,35 @@
 (function() {
   const STORAGE_KEY = 'qgis-preferred-language';
   const DEFAULT_LANG = 'en';
+  const STORAGE_EXPIRY_DAYS = 365;
+
+  // Save language preference with a timestamp for expiry tracking.
+  // English is saved explicitly so that lang-redirect.js can detect
+  // that the user deliberately chose English and not auto-redirect.
+  function saveLang(lang) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ lang: lang || DEFAULT_LANG, ts: Date.now() }));
+    } catch (e) { /* storage unavailable */ }
+  }
+
+  // Load language preference, returning null if absent or expired.
+  // Backwards-compatible with the old plain-string format.
+  function loadLang() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return null;
+      let data;
+      try { data = JSON.parse(raw); } catch (e) { return raw; } // old plain-string
+      if (!data || typeof data !== 'object') return String(raw);
+      if ((Date.now() - data.ts) / 86400000 > STORAGE_EXPIRY_DAYS) {
+        localStorage.removeItem(STORAGE_KEY);
+        return null;
+      }
+      return data.lang || null;
+    } catch (e) {
+      return null;
+    }
+  }
 
   /**
    * Initialize language switcher
@@ -62,31 +91,27 @@
   }
 
   /**
-   * Restore saved language preference
-   * Redirects to saved language if on root path and coverage is sufficient
+   * Restore saved language preference.
+   * Redirects to saved language only after verifying the target page exists,
+   * preventing redirect loops when a page hasn't been translated.
    */
   function restoreSavedLanguage() {
-    const savedLang = localStorage.getItem(STORAGE_KEY);
-    
-    if (!savedLang || savedLang === DEFAULT_LANG) {
-      return; // No saved preference or saved as English
-    }
-    
-    // Check if we're on a non-prefixed URL (root or English content)
+    const savedLang = loadLang();
+    if (!savedLang || savedLang === DEFAULT_LANG) return;
+
     const pathname = window.location.pathname;
     const parts = pathname.split('/').filter(Boolean);
-    
-    // If already on a language-prefixed URL, don't redirect
     const langPattern = /^[a-z]{2}(-[a-z]{2,}|_[a-z]{2})?$/i;
-    if (parts.length > 0 && langPattern.test(parts[0])) {
-      return; // Already on a language-prefixed URL
-    }
-    
-    // Redirect to saved language if not already there
-    if (savedLang !== DEFAULT_LANG) {
-      const newPath = `/${savedLang}${pathname}`;
-      window.location.href = newPath;
-    }
+    if (parts.length > 0 && langPattern.test(parts[0])) return; // already on a language-prefixed URL
+
+    const newPath = `/${savedLang}${pathname}`;
+    // HEAD-check before redirecting: if the translated page doesn't exist,
+    // stay on the current page rather than bouncing to a 404.
+    fetch(newPath, { method: 'HEAD' })
+      .then(function(resp) {
+        if (resp.ok) window.location.href = newPath;
+      })
+      .catch(function() { /* network error — stay on current page */ });
   }
 
   /**
@@ -102,12 +127,8 @@
         const lang = this.getAttribute('data-lang');
         const langName = this.textContent;
         
-        // Save to localStorage
-        if (lang === DEFAULT_LANG) {
-          localStorage.removeItem(STORAGE_KEY);
-        } else {
-          localStorage.setItem(STORAGE_KEY, lang);
-        }
+        // Save to localStorage (with expiry timestamp)
+        saveLang(lang);
         
         // Update display
         updateLanguageDisplay(lang);


### PR DESCRIPTION
Closes https://github.com/qgis/QGIS-Website/issues/966

- The auto-redirect on first visit will use the same list of eligible languages as the dropdown, instead of a stale per-build subset
- Selecting English on a non-English system will no longer reverts back to the system language; the choice will be remembered
- Language preferences expire after 365 days instead of being stored forever
- Redirecting to a saved language preference will no longer risks a redirect loop when a page hasn't been translated; the redirect will only be followed if the page actually exists
